### PR TITLE
Set `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` in review app setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -14,7 +14,7 @@ end
 
 chdir APP_ROOT do
   if ENV["RAILS_ENV"] == "production"
-    system! "bin/rails db:schema:load"
+    system! "bin/rails db:schema:load DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
     system! "bin/rails db:seed"
   else
     system! "bundle install"


### PR DESCRIPTION
Rails 5 prevents potentially destructive db commands in
`RAILS_ENV=production` (which review apps run with).

Review apps are currently failing with

```
Tasks: TOP => db:schema:load => db:check_protected_environments
(See full trace by running task with --trace)

== Command ["bin/rails db:schema:load"] failed ==
```